### PR TITLE
Included a special case for 'Media' blocks, so that they get included…

### DIFF
--- a/lib/Commands.ts
+++ b/lib/Commands.ts
@@ -123,12 +123,11 @@ export default class Commands {
 				.then(async (blocks) => {
 					for (const block of blocks) {
 						if (
-							block.class === "Channel" ||
-							block.class === "Media"
+							block.class === "Channel"
 						) {
 							continue;
 						}
-						const fileName = block.generated_title
+						let fileName = block.generated_title
 							? block.generated_title
 							: block.title;
 
@@ -146,6 +145,25 @@ export default class Commands {
 						if (block.class === "Image" || block.class === "Link") {
 							const imageUrl = block.image?.display.url;
 							content = `![](${imageUrl})`;
+						}
+
+						// Hack for Youtube Embeds, might work for others as well
+						if (block.class === "Media") {
+							let mediaUrl = block.embed?.html;
+							fileName = block.source.title;
+							content = `${mediaUrl}`;
+						}
+
+						// Fix for long file names
+						const maxLength = 255;
+						const pathLength = `${this.settings.folder}/${slug}`.length;
+						
+						if(pathLength + fileName.length >= maxLength) {
+							let extIndex = fileName.lastIndexOf('.');
+							let name = extIndex === -1 ? fileName : fileName.substring(0, extIndex);
+							let extension = extIndex === -1 ? '' : fileName.substring(extIndex);
+
+							fileName = name.substring(0, maxLength - extension.length - pathLength) + extension;
 						}
 
 						try {

--- a/lib/Modals.ts
+++ b/lib/Modals.ts
@@ -127,7 +127,7 @@ export class BlocksModal extends FuzzySuggestModal<Block> {
 	getItems(): Block[] {
 		if (this.blocks) {
 			return this.blocks.filter(
-				(block) => block.class !== "Channel" && block.class !== "Media",
+				(block) => block.class !== "Channel"
 			);
 		}
 		return this.blocks;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -74,6 +74,18 @@ export interface Image {
 	thumb: URL;
 	updated_at: string;
 }
+export interface Embed {
+	url: URL;
+	type: string;
+	title: string;
+	author_name: string;
+	author_url: URL;
+	source_url: URL;
+	thumbnail_url: URL;
+	width: Number;
+	height: Number;
+	html: string;
+}
 
 export interface Block {
 	user: User;
@@ -93,7 +105,7 @@ export interface Block {
 	created_at: string;
 	description: string;
 	description_html: string;
-	embed: string;
+	embed: Embed;
 	generated_title: string;
 	position: number;
 	slug: string;


### PR DESCRIPTION
… when pulling. YouTube blocks were ignored, for example, and I wanted to have the present as well. I also made a small fix for the error of too long of a file path. I had some images that were weirdly named in the original. They were too long and the .md file couldn't be created.