### PR TITLE
Bump release workflow actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
             attestations: write
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v6
 
             - name: Use Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v6
               with:
-                  node-version: "18.x"
+                  node-version: "20.x"
 
             - name: Build plugin
               run: |
@@ -28,7 +28,7 @@ jobs:
                   npm run build
 
             - name: Attest build provenance
-              uses: actions/attest-build-provenance@v2
+              uses: actions/attest-build-provenance@v4
               with:
                   subject-path: |
                       main.js


### PR DESCRIPTION
The v1.3.0 release run succeeded but flagged a deprecation: `actions/checkout@v3`, `actions/setup-node@v3`, and the attest actions run on **Node.js 20**, which GitHub will force to Node 24 on **2026-06-16** and remove on **2026-09-16**.

Bumps each action to the current major that ships a Node 24 runtime, and moves `node-version` off the EOL 18.x line:

- `actions/checkout@v3` → `@v6`
- `actions/setup-node@v3` → `@v6`
- `actions/attest-build-provenance@v2` → `@v4`
- `node-version` `18.x` → `20.x`

No behavior change to the release itself — same build, same attested assets (`main.js`, `manifest.json`, `styles.css`), same draft-release step. Verifiable on the next tag push.